### PR TITLE
Docs: Update docs link to new page

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ $highlighter = new \Tempest\Highlight\Highlighter();
 $code = $highlighter->parse($code, 'php');
 ```
 
-Continue reading in the docs: [https://tempestphp.com/docs/highlight/01-getting-started](https://tempestphp.com/docs/highlight/01-getting-started).
+Continue reading in the docs: [https://tempestphp.com/main/packages/highlight](https://tempestphp.com/main/packages/highlight).


### PR DESCRIPTION
This pull request updates the link to the project's documentation page in the `README.md` file.

The old docs link was showing a 404 error, but no worries! The documentation has a new home, and this update means users will always land on the correct and current page.